### PR TITLE
Fix error parsing latex_symbols.js from Julia.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,6 +1,8 @@
-# Task # 1
+# Task # 1 - https://github.com/ipython/ipython/issues/12861
 
-https://github.com/ipython/ipython/issues/12861
+accidentalrebel: Made a pull request. https://github.com/code-relay-io/ipython/pull/1
+
+# Task # 2 - Double check if newly generated `latex_symbols.py` is complete and are working in IPython.
 
 Remember your job is to make *incremental* progress, break the task into smaller tasks, or finish something in 15 minutes, then pass it along to the next contributor. 
 No responsibility, only fun.

--- a/tools/gen_latex_symbols.py
+++ b/tools/gen_latex_symbols.py
@@ -35,7 +35,8 @@ idents = []
 for l in lines[symbols_line:]:
     if not '=>' in l: continue # if it's not a def, skip
     if '#' in l: l = l[:l.index('#')] # get rid of eol comments
-    x, y = l.strip().split('=>') 
+    x, y = l.strip().split('=>')
+    if not '"' in x or not '"' in y: continue # if there's no ", skip
     if '*' in x: # if a prefix is present substitute it with its value
         p, x = x.split('*')
         x = prefix_dict[p][:-1] + x[1:]


### PR DESCRIPTION
This fix makes sure that the code checks if whether each parsed line has a `"` character. Otherwise it skips it.

This is the first step to allow iPython to parse and update it's latex symbols. Related to https://github.com/ipython/ipython/issues/12861.

Before this fix, an error occurs when `gen_latex_symbols.py` is called.

```
$ python3 gen_latex_symbols.py 
Importing latex_symbols.js from Julia...
Building a list of (latex, unicode) key-value pairs...
Traceback (most recent call last):
  File "/home/arebel/development/open-source/ipython/tools/gen_latex_symbols.py", line 42, in <module>
    x, y = x.split('"')[1], y.split('"')[1] # get the values in quotes
IndexError: list index out of range
```

This is caused by line 2629 of: https://raw.githubusercontent.com/JuliaLang/julia/master/stdlib/REPL/src/latex_symbols.jl.


