### PR TITLE
Remove identifier check for LaTeX commands

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -2,6 +2,10 @@
 
 https://github.com/ipython/ipython/issues/12861
 
+# Task # 2
+
+Investigate why tools/gen_latex_symbols.py fails to decode \U1d4c1 mathematical script small l in latex_symbols.jl
+
 Remember your job is to make *incremental* progress, break the task into smaller tasks, or finish something in 15 minutes, then pass it along to the next contributor. 
 No responsibility, only fun.
 

--- a/tools/gen_latex_symbols.py
+++ b/tools/gen_latex_symbols.py
@@ -54,7 +54,7 @@ def test_ident(i):
 assert test_ident("α")
 assert not test_ident('‴')
 
-valid_idents = [line for line in idents if test_ident(line[1])]
+valid_idents = idents
 
 # Write the `latex_symbols.py` module in the cwd
 


### PR DESCRIPTION
Remove the check that LaTeX commands must be valid Python identifiers.
This allows users to input glyphs like the root symbol with \sqrt.

When merged with #1, this creates a new problem: not all commands in
latex_symbols.jl can be parsed correctly.
```
> python3 -m IPython
Traceback (most recent call last):
  File "/usr/lib/python3.8/runpy.py", line 185, in _run_module_as_main
    mod_name, mod_spec, code = _get_module_details(mod_name, _Error)
  File "/usr/lib/python3.8/runpy.py", line 144, in _get_module_details
    return _get_module_details(pkg_main_name, error)
  File "/usr/lib/python3.8/runpy.py", line 111, in _get_module_details
    __import__(pkg_name)
  File "/home/david/Downloads/ipython/IPython/__init__.py", line 56, in <module>
    from .terminal.embed import embed
  File "/home/david/Downloads/ipython/IPython/terminal/embed.py", line 16, in <module>
    from IPython.terminal.interactiveshell import TerminalInteractiveShell
  File "/home/david/Downloads/ipython/IPython/terminal/interactiveshell.py", line 47, in <module>
    from .debugger import TerminalPdb, Pdb
  File "/home/david/Downloads/ipython/IPython/terminal/debugger.py", line 7, in <module>
    from IPython.core.completer import IPCompleter
  File "/home/david/Downloads/ipython/IPython/core/completer.py", line 133, in <module>
    from IPython.core.latex_symbols import latex_symbols, reverse_latex_symbol
  File "/home/david/Downloads/ipython/IPython/core/latex_symbols.py", line 1662
    "\\scrl" : "\U1d4c1",
               ^
SyntaxError: (unicode error) 'unicodeescape' codec can't decode bytes in position 0-6: truncated \UXXXXXXXX escape
```
You can type LaTeX Unicode commands as desired if the offending lines
are deleted from `IPython/core/latex_symbols.py`.